### PR TITLE
Fix build on UE 5.4

### DIFF
--- a/Source/JsonAsAsset/Public/Importers/Types/Physics/PhysicsAssetImporter.h
+++ b/Source/JsonAsAsset/Public/Importers/Types/Physics/PhysicsAssetImporter.h
@@ -7,6 +7,9 @@
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION > 4
 #include "PhysicsEngine/PhysicsConstraintTemplate.h"
 #include "PhysicsEngine/SkeletalBodySetup.h"
+#elif ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION == 4
+#include "PhysicsEngine/PhysicsConstraintTemplate.h"
+#include "PhysicsEngine/PhysicsAsset.h"
 #endif
 
 class IPhysicsAssetImporter : public IImporter {


### PR DESCRIPTION
Build was failing due to missing USkeletalBodySetup, but it's not defined in SkeletalBodySetup.h. UE 5.4 instead has that definition in PhysicsAsset.h

I haven't been able to verify if PhysicsAssetImporter works, as I don't have a sample JSON, but it compiles without errors now.

Tested on 5.4.4

