### PR TITLE
Feature/user defined structs

### DIFF
--- a/Source/JsonAsAsset/Private/Importers/Constructor/Importer.cpp
+++ b/Source/JsonAsAsset/Private/Importers/Constructor/Importer.cpp
@@ -345,7 +345,9 @@ template <typename T>
 void IImporter::LoadObject(const TSharedPtr<FJsonObject>* PackageIndex, TObjectPtr<T>& Object) {
 	FString ObjectType, ObjectName, ObjectPath, Outer;
 	PackageIndex->Get()->GetStringField(TEXT("ObjectName")).Split("'", &ObjectType, &ObjectName);
-	PackageIndex->Get()->GetStringField(TEXT("ObjectPath")).Split(".", &ObjectPath, nullptr);
+
+	ObjectPath = PackageIndex->Get()->GetStringField(TEXT("ObjectPath"));
+	ObjectPath.Split(".", &ObjectPath, nullptr);
 
 	const UJsonAsAssetSettings* Settings = GetDefault<UJsonAsAssetSettings>();
 

--- a/Source/JsonAsAsset/Private/Importers/Types/UserDefinedStructImporter.cpp
+++ b/Source/JsonAsAsset/Private/Importers/Types/UserDefinedStructImporter.cpp
@@ -1,0 +1,156 @@
+/* Copyright JAA Contributors 2024-2025 */
+
+#include "Importers/Types/UserDefinedStructImporter.h"
+
+#include "Dom/JsonObject.h"
+#include "Factories/StructureFactory.h"
+#include "Kismet2/StructureEditorUtils.h"
+#include "UserDefinedStructure/UserDefinedStructEditorData.h"
+#include "Utilities/AssetUtilities.h"
+
+static const FRegexPattern
+    PropertyNameRegexPattern(TEXT(R"((.*)_(\d+)_([0-9A-Z]+))"));
+
+static const TMap<FString, const FName> PropertyCategoryMap = {
+    {TEXT("BoolProperty"), TEXT("bool")},
+    {TEXT("ByteProperty"), TEXT("byte")},
+    {TEXT("IntProperty"), TEXT("int")},
+    {TEXT("Int64Property"), TEXT("int64")},
+    {TEXT("FloatProperty"), TEXT("real")},
+    {TEXT("DoubleProperty"), TEXT("real")},
+    {TEXT("StrProperty"), TEXT("string")},
+    {TEXT("TextProperty"), TEXT("text")},
+    {TEXT("NameProperty"), TEXT("name")},
+    {TEXT("ClassProperty"), TEXT("class")},
+    {TEXT("SoftClassProperty"), TEXT("softclass")},
+    {TEXT("ObjectProperty"), TEXT("object")},
+    {TEXT("SoftObjectProperty"), TEXT("softobject")},
+    {TEXT("EnumProperty"), TEXT("byte")},
+    {TEXT("StructProperty"), TEXT("struct")},
+};
+
+static const TMap<FString, EPinContainerType> ContainerTypeMap = {
+    {TEXT("ArrayProperty"), EPinContainerType::Array},
+    {TEXT("MapProperty"), EPinContainerType::Map},
+    {TEXT("SetProperty"), EPinContainerType::Set},
+};
+
+bool IUserDefinedStructImporter::Import() {
+  UUserDefinedStruct *UserDefinedStruct = FStructureEditorUtils::CreateUserDefinedStruct(Package, *FileName, RF_Standalone | RF_Public | RF_Transactional);
+
+  /* Remove default variable */
+  FStructureEditorUtils::GetVarDesc(UserDefinedStruct).Pop();
+
+  const TArray<TSharedPtr<FJsonValue>> ChildProperties = AssetData->GetArrayField(TEXT("ChildProperties"));
+  for (const TSharedPtr<FJsonValue> Property : ChildProperties) {
+    const TSharedPtr<FJsonObject> PropertyObject = Property->AsObject();
+    ImportPropertyIntoStruct(UserDefinedStruct, PropertyObject);
+  }
+
+  /* Handle edit changes, and add it to the content browser */
+  return OnAssetCreation(UserDefinedStruct);
+}
+
+void IUserDefinedStructImporter::ImportPropertyIntoStruct(UUserDefinedStruct *Struct, const TSharedPtr<FJsonObject> &PropertyJsonObject) {
+  const FString Name = PropertyJsonObject->GetStringField(TEXT("Name"));
+  const FString Type = PropertyJsonObject->GetStringField(TEXT("Type"));
+
+  FString FieldDisplayName = Name;
+  FString FieldId = "1";
+  FGuid FieldGuid = FGuid();
+
+  FRegexMatcher RegexMatcher(PropertyNameRegexPattern, Name);
+  if (RegexMatcher.FindNext()) {
+    /* Import properties keeping GUID if present */
+    FieldDisplayName = RegexMatcher.GetCaptureGroup(1);
+    FieldId = RegexMatcher.GetCaptureGroup(2);
+    FieldGuid = FGuid(RegexMatcher.GetCaptureGroup(3));
+  } else {
+    const uint32 UniqueNameId = CastChecked<UUserDefinedStructEditorData>(Struct->EditorData)->GenerateUniqueNameIdForMemberVariable();
+    FieldId = FString::FromInt(UniqueNameId);
+    FieldGuid = FGuid::NewGuid();
+  }
+
+  const FName FormattedName = *FString::Printf(TEXT("%s_%s_%s"), *FieldDisplayName, *FieldId, *FieldGuid.ToString(EGuidFormats::Digits));
+
+  FStructVariableDescription Variable;
+  Variable.VarName = FormattedName;
+  Variable.FriendlyName = FieldDisplayName;
+  Variable.VarGuid = FieldGuid;
+  Variable.SetPinType(ResolvePropertyPinType(PropertyJsonObject));
+
+  FStructureEditorUtils::GetVarDesc(Struct).Add(Variable);
+  FStructureEditorUtils::OnStructureChanged(Struct, FStructureEditorUtils::EStructureEditorChangeInfo::AddedVariable);
+}
+
+FEdGraphPinType IUserDefinedStructImporter::ResolvePropertyPinType(const TSharedPtr<FJsonObject> &PropertyJsonObject) {
+  const FString Type = PropertyJsonObject->GetStringField(TEXT("Type"));
+
+  /* Special handling for containers */
+  const EPinContainerType *ContainerType = ContainerTypeMap.Find(Type);
+  if (ContainerType) {
+    if (*ContainerType == EPinContainerType::Map) {
+      TSharedPtr<FJsonObject> KeyPropObject = PropertyJsonObject->GetObjectField(TEXT("KeyProp"));
+      FEdGraphPinType ResolvedType = ResolvePropertyPinType(KeyPropObject);
+      ResolvedType.ContainerType = *ContainerType;
+
+      TSharedPtr<FJsonObject> ValuePropObject = PropertyJsonObject->GetObjectField(TEXT("ValueProp"));
+      FEdGraphPinType ResolvedTerminalType = ResolvePropertyPinType(ValuePropObject);
+      ResolvedType.PinValueType.TerminalCategory = ResolvedTerminalType.PinCategory;
+      ResolvedType.PinValueType.TerminalSubCategory = ResolvedTerminalType.PinSubCategory;
+      ResolvedType.PinValueType.TerminalSubCategoryObject = ResolvedTerminalType.PinSubCategoryObject;
+
+      return ResolvedType;
+    } else if (*ContainerType == EPinContainerType::Set) {
+      TSharedPtr<FJsonObject> ElementPropObject = PropertyJsonObject->GetObjectField(TEXT("ElementProp"));
+      FEdGraphPinType ResolvedType = ResolvePropertyPinType(ElementPropObject);
+      ResolvedType.ContainerType = *ContainerType;
+      return ResolvedType;
+    } else if (*ContainerType == EPinContainerType::Array) {
+      TSharedPtr<FJsonObject> InnerTypeObject = PropertyJsonObject->GetObjectField(TEXT("Inner"));
+      FEdGraphPinType ResolvedType = ResolvePropertyPinType(InnerTypeObject);
+      ResolvedType.ContainerType = *ContainerType;
+      return ResolvedType;
+    }
+  }
+
+  FEdGraphPinType ResolvedType = FEdGraphPinType(NAME_None, NAME_None, nullptr, EPinContainerType::None,false, FEdGraphTerminalType());
+
+  /* Find main type from our PropertyCategoryMap */
+  const FName *TypeCategory = PropertyCategoryMap.Find(Type);
+  if (TypeCategory) {
+    ResolvedType.PinCategory = *TypeCategory;
+  } else {
+    UE_LOG(LogJson, Warning, TEXT("Type '%s' not found in PropertyCategoryMap, defaulting to 'Byte'"), *Type);
+    ResolvedType.PinCategory = TEXT("byte");
+  }
+
+  /* Special handling for some types */
+  if (Type == "DoubleProperty") {
+    ResolvedType.PinSubCategory = TEXT("double");
+  } else if (Type == "FloatProperty") {
+    ResolvedType.PinSubCategory = TEXT("float");
+  } else if ((Type == "EnumProperty" || Type == "ByteProperty")) {
+    ResolvedType.PinSubCategoryObject = LoadObjectFromJsonReference(PropertyJsonObject, TEXT("Enum"));
+  } else if (Type == "StructProperty") {
+    ResolvedType.PinSubCategoryObject = LoadObjectFromJsonReference(PropertyJsonObject, TEXT("Struct"));
+  } else if (Type == "ClassProperty" || Type == "SoftClassProperty") {
+    ResolvedType.PinSubCategoryObject = LoadObjectFromJsonReference(PropertyJsonObject, TEXT("MetaClass"));
+  } else if (Type == "ObjectProperty" || Type == "SoftObjectProperty") {
+    ResolvedType.PinSubCategoryObject = LoadObjectFromJsonReference(PropertyJsonObject, TEXT("PropertyClass"));
+  }
+
+  return ResolvedType;
+}
+
+UObject *IUserDefinedStructImporter::LoadObjectFromJsonReference(const TSharedPtr<FJsonObject> &ParentJsonObject, const FString &ReferenceKey) {
+  const TSharedPtr<FJsonObject> ReferenceObject = ParentJsonObject->GetObjectField(ReferenceKey);
+  if (!ReferenceObject) {
+    UE_LOG(LogJson, Error, TEXT("Failed to load Object from poperty %s: property not found"), *ReferenceKey);
+    return nullptr;
+  }
+
+  TObjectPtr<UObject> LoadedObject;
+  LoadObject<UObject>(&ReferenceObject, LoadedObject);
+  return LoadedObject;
+}

--- a/Source/JsonAsAsset/Private/Modules/LocalFetchModule.cpp
+++ b/Source/JsonAsAsset/Private/Modules/LocalFetchModule.cpp
@@ -58,6 +58,11 @@ TArray<FString> LocalFetchAcceptedTypes = {
 	"SubsurfaceProfile",
 	"LandscapeGrassType",
 	"DataTable",
+
+	"", // separator
+
+	"UserDefinedStruct",
+	"UserDefinedEnum"
 };
 
 bool LocalFetchModule::LaunchLocalFetch() {

--- a/Source/JsonAsAsset/Public/Importers/Types/UserDefinedStructImporter.h
+++ b/Source/JsonAsAsset/Public/Importers/Types/UserDefinedStructImporter.h
@@ -1,0 +1,26 @@
+/* Copyright JAA Contributors 2024-2025 */
+
+#pragma once
+
+#include "Importers/Constructor/Importer.h"
+#include "Engine/UserDefinedStruct.h"
+
+class IUserDefinedStructImporter : public IImporter {
+public:
+	IUserDefinedStructImporter(const FString& FileName, const FString& FilePath, const TSharedPtr<FJsonObject>& JsonObject, UPackage* Package, UPackage* OutermostPkg, const TArray<TSharedPtr<FJsonValue>>& AllJsonObjects, UClass* AssetClass):
+		IImporter(FileName, FilePath, JsonObject, Package, OutermostPkg, AllJsonObjects, AssetClass) {
+	}
+
+	virtual bool Import() override;
+
+protected:
+	FEdGraphPinType ResolvePropertyPinType(const TSharedPtr<FJsonObject>& PropertyJsonObject);
+	
+	UObject* LoadObjectFromJsonReference(const TSharedPtr<FJsonObject>& ParentJsonObject, const FString& ReferenceKey);
+	
+	void ImportPropertyIntoStruct(UUserDefinedStruct* Struct, const TSharedPtr<FJsonObject>& PropertyJsonObject);
+};
+
+REGISTER_IMPORTER(IUserDefinedStructImporter, {
+	TEXT("UserDefinedStruct")
+}, "User Defined Assets");


### PR DESCRIPTION
This PR adds support to importing UserDefinedStruct JSON files. All property types are supported, including containers. 

Tested using Abiotic Factor on UE 5.4.4

Please note that there is a special logic used to maintain original property GUIDs, which is required for some games. Currently, no other tool supports this.