### PR TITLE
Unreal Engine 5.8

### DIFF
--- a/Source/Reflection/Private/Importers/Types/Blueprint/AnimationBlueprintImporter.cpp
+++ b/Source/Reflection/Private/Importers/Types/Blueprint/AnimationBlueprintImporter.cpp
@@ -117,17 +117,19 @@ bool IAnimationBlueprintImporter::Import() {
 	ProcessEvaluateGraphExposedInputs(RootAnimNodeProperties);
 
 	/* Parse LinkIDs to proper Node IDs ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
-	RootAnimNodeProperties->Values.GetKeys(NodesKeys);
-	
+	for (const auto& Pair : RootAnimNodeProperties->Values) {
+		NodesKeys.Add(JsonKeyToString(Pair.Key));
+	}
+
 	ReversedNodesKeys = NodesKeys;
 	Algo::Reverse(ReversedNodesKeys);
 
 	for (const FString& Key : NodesKeys) {
-		TSharedPtr<FJsonValue> NodeValue = RootAnimNodeProperties->Values.FindChecked(Key);
+		TSharedPtr<FJsonValue> NodeValue = RootAnimNodeProperties->Values.FindChecked(StringToJsonKey(Key));
 		if (!NodeValue.IsValid()) continue;
-		
+
 		ReplaceLinkID(NodeValue, NodesKeys);
-		RootAnimNodeProperties->Values[Key] = NodeValue;
+		RootAnimNodeProperties->Values[StringToJsonKey(Key)] = NodeValue;
 	}
 
 	/* Sets "State" and "Machine" for each state result */
@@ -157,7 +159,7 @@ bool IAnimationBlueprintImporter::Import() {
 	/* Separate main graph nodes (without "State" and "Machine") into RootGraphAnimProperties ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 	const TSharedPtr<FJsonObject> RootGraphAnimProperties = MakeShared<FJsonObject>(); {
 		for (const FString& Key : NodesKeys) {
-			const TSharedPtr<FJsonValue> NodeValue = RootAnimNodeProperties->Values.FindChecked(Key);
+			const TSharedPtr<FJsonValue> NodeValue = RootAnimNodeProperties->Values.FindChecked(StringToJsonKey(Key));
 		
 			if (NodeValue->Type == EJson::Object) {
 				const TSharedPtr<FJsonObject> NodeObject = NodeValue->AsObject();
@@ -261,7 +263,7 @@ void IAnimationBlueprintImporter::CreateGraph(const TSharedPtr<FJsonObject>& Ani
 				TSharedPtr<FJsonObject> StateMachineAnimNodeProperties = MakeShared<FJsonObject>();
 
 				for (const auto& Pair : RootAnimNodeProperties->Values) {
-					const  FString Key = Pair.Key;
+					const FString Key = JsonKeyToString(Pair.Key);
 					const TSharedPtr<FJsonObject> Value = Pair.Value->AsObject();
 
 					if (!Value.IsValid()) continue;
@@ -406,7 +408,7 @@ void IAnimationBlueprintImporter::UpdateBlendListByEnumVisibleEntries(FUObjectEx
 
 void IAnimationBlueprintImporter::CreateAnimGraphNodes(UEdGraph* AnimGraph, const TSharedPtr<FJsonObject>& AnimNodeProperties, FUObjectExportContainer& OutContainer) {
 	for (const auto& Pair : AnimNodeProperties->Values) {
-		FString Key = Pair.Key;
+		FString Key = JsonKeyToString(Pair.Key);
 
 		TSharedPtr<FJsonObject> Value = Pair.Value->AsObject();
 
@@ -544,9 +546,9 @@ void IAnimationBlueprintImporter::HandleNodeDeserialization(FUObjectExportContai
 			auto& RootValues = NodeExport->JsonObject->Values;
 
 			auto MoveField = [&](const FString& Key) {
-				if (RootValues.Contains(Key)) {
+				if (RootValues.Contains(StringToJsonKey(Key))) {
 					if (Key == TEXT("LocalJointOffset")) {
-						TSharedPtr<FJsonObject> Original = RootValues[Key]->AsObject();
+						TSharedPtr<FJsonObject> Original = RootValues[StringToJsonKey(Key)]->AsObject();
 
 						if (Original.IsValid()) {
 							TSharedPtr<FJsonObject> VecObj = MakeShared<FJsonObject>(*Original);
@@ -565,7 +567,7 @@ void IAnimationBlueprintImporter::HandleNodeDeserialization(FUObjectExportContai
 						}
 					}
 
-					PhysicsBodyDefinition->SetField(Key, RootValues[Key]);
+					PhysicsBodyDefinition->SetField(Key, RootValues[StringToJsonKey(Key)]);
 				}
 			};
 
@@ -650,7 +652,7 @@ void IAnimationBlueprintImporter::ConnectAnimGraphNodes(FUObjectExportContainer*
         }
     	
         for (const auto& Pair : Json->Values) {
-            const FString& Key = Pair.Key;
+            const FString Key = JsonKeyToString(Pair.Key);
             const TSharedPtr<FJsonValue>& Value = Pair.Value;
             
             if (Value->Type == EJson::Array) {
@@ -683,7 +685,7 @@ void IAnimationBlueprintImporter::ConnectAnimGraphNodes(FUObjectExportContainer*
                     for (TFieldIterator<FProperty> It(NodeProp->Struct); It; ++It) {
                         FProperty* Property = *It;
                         
-                        if (Property->GetName() != Pair.Key) {
+                        if (Property->GetName() != JsonKeyToString(Pair.Key)) {
                             continue;
                         }
                         
@@ -718,7 +720,7 @@ void IAnimationBlueprintImporter::ConnectAnimGraphNodes(FUObjectExportContainer*
                 for (TFieldIterator<FProperty> It(NodeProp->Struct); It; ++It) {
                     const FProperty* Property = *It;
                     
-                    if (Property->GetName() != Pair.Key) {
+                    if (Property->GetName() != JsonKeyToString(Pair.Key)) {
                         continue;
                     }
                     

--- a/Source/Reflection/Private/Importers/Types/Blueprint/BlueprintImporter.cpp
+++ b/Source/Reflection/Private/Importers/Types/Blueprint/BlueprintImporter.cpp
@@ -237,7 +237,8 @@ void IBlueprintImporter::ConstructWidgetTree() {
 				}
 			}
 			
-			for (const FMovieSceneBinding& Binding : WidgetAnimation->MovieScene->GetBindings()) {
+			const UMovieScene* MovieScene = WidgetAnimation->MovieScene;
+			for (const FMovieSceneBinding& Binding : MovieScene->GetBindings()) {
 				for (UMovieSceneTrack* Track : Binding.GetTracks()) {
 					Track->Modify();
 					Track->MarkAsChanged();

--- a/Source/Reflection/Private/Importers/Types/Blueprint/Utilities/AnimationBlueprintUtilities.h
+++ b/Source/Reflection/Private/Importers/Types/Blueprint/Utilities/AnimationBlueprintUtilities.h
@@ -70,7 +70,7 @@ inline void ReplaceLinkID(const TSharedPtr<FJsonValue>& Data, const TArray<FStri
 					Pair.Value = MakeShared<FJsonValueString>(NodesKeys[Index]);
 				}
 			} else {
-				ReplaceLinkID(Pair.Value, NodesKeys, Pair.Key);
+				ReplaceLinkID(Pair.Value, NodesKeys, JsonKeyToString(Pair.Key));
 			}
 		}
 	} else if (Data->Type == EJson::Array) {
@@ -87,13 +87,13 @@ inline void FilterAnimGraphNodeProperties(const TSharedPtr<FJsonObject>& JsonObj
 	
 	TArray<FString> KeysToRemove;
 	for (auto& Pair : JsonObject->Values) {
-		if (!Pair.Key.Contains(TEXT("AnimGraphNode"))) {
-			KeysToRemove.Add(Pair.Key);
+		if (!JsonKeyToString(Pair.Key).Contains(TEXT("AnimGraphNode"))) {
+			KeysToRemove.Add(JsonKeyToString(Pair.Key));
 		}
 	}
-	
+
 	for (const FString& Key : KeysToRemove) {
-		JsonObject->Values.Remove(Key);
+		JsonObject->Values.Remove(StringToJsonKey(Key));
 	}
 }
 
@@ -107,13 +107,13 @@ inline TArray<TPair<FString, FString>> FindLinkIDs(const TSharedPtr<FJsonValue>&
         for (auto& Pair : Object->Values) {
             if (Pair.Key == TEXT("LinkID")) {
                 FString LinkStr = Pair.Value->AsString();
-                FString Prop = ParentProperty.IsEmpty() ? Pair.Key : ParentProperty;
+                FString Prop = ParentProperty.IsEmpty() ? JsonKeyToString(Pair.Key) : ParentProperty;
             	
                 Results.Add(TPair<FString, FString>(Prop, LinkStr));
             	continue;
             }
         	
-            TArray<TPair<FString, FString>> SubResults = FindLinkIDs(Pair.Value, Pair.Key);
+            TArray<TPair<FString, FString>> SubResults = FindLinkIDs(Pair.Value, JsonKeyToString(Pair.Key));
             Results.Append(SubResults);
         }
     } else if (Data->Type == EJson::Array) {
@@ -129,17 +129,18 @@ inline TArray<TPair<FString, FString>> FindLinkIDs(const TSharedPtr<FJsonValue>&
     return Results;
 }
 
-inline void HarvestAndTagConnectedStateMachineNodes(const FString& StartKey, const FString& StateName, const FString& MachineName, TMap<FString, TSharedPtr<FJsonValue>>& Nodes) {
-	if (!Nodes.Contains(StartKey)) return;
+template <typename KeyType>
+inline void HarvestAndTagConnectedStateMachineNodes(const FString& StartKey, const FString& StateName, const FString& MachineName, TMap<KeyType, TSharedPtr<FJsonValue>>& Nodes) {
+	if (!Nodes.Contains(StringToJsonKey(StartKey))) return;
 
-	const TSharedPtr<FJsonValue> NodeValue = Nodes.FindChecked(StartKey);
-	
+	const TSharedPtr<FJsonValue> NodeValue = Nodes.FindChecked(StringToJsonKey(StartKey));
+
 	if (NodeValue->Type == EJson::Object) {
 		TSharedPtr<FJsonObject> NodeObject = NodeValue->AsObject();
 		NodeObject->SetStringField(TEXT("State"), StateName);
 		NodeObject->SetStringField(TEXT("Machine"), MachineName);
-		
-		Nodes[StartKey] = MakeShared<FJsonValueObject>(NodeObject);
+
+		Nodes[StringToJsonKey(StartKey)] = MakeShared<FJsonValueObject>(NodeObject);
 	}
 	
 	TArray<TPair<FString, FString>> Links = FindLinkIDs(NodeValue, StartKey);

--- a/Source/Reflection/Private/Importers/Types/Physics/PhysicsAssetImporter.cpp
+++ b/Source/Reflection/Private/Importers/Types/Physics/PhysicsAssetImporter.cpp
@@ -84,7 +84,7 @@ bool IPhysicsAssetImporter::Import() {
 	}), PhysicsAsset);
 
 	/* If the user selected a skeletal mesh in the browser, set it in the physics asset */
-	const USkeletalMesh* SkeletalMesh = GetSelectedAsset<USkeletalMesh>(true);
+	USkeletalMesh* SkeletalMesh = GetSelectedAsset<USkeletalMesh>(true);
 
 	/* Otherwise, fallback to any skeletal mesh sitting in the same folder as the physics asset */
 	if (!SkeletalMesh) {

--- a/Source/Reflection/Private/Importers/Types/Tables/DataTableImporter.cpp
+++ b/Source/Reflection/Private/Importers/Types/Tables/DataTableImporter.cpp
@@ -53,7 +53,7 @@ bool IDataTableImporter::Import() {
 	const TSharedPtr<FJsonObject> RowData = GetAssetData()->GetObjectField(TEXT("Rows"));
 
 	/* Loop throughout row data, and deserialize */
-	for (TPair<FString, TSharedPtr<FJsonValue>>& Pair : RowData->Values) {
+	for (const auto& Pair : RowData->Values) {
 		const TSharedPtr<FStructOnScope> ScopedStruct = MakeShareable(new FStructOnScope(TableRowStruct));
 		TSharedPtr<FJsonObject> StructData = Pair.Value->AsObject();
 

--- a/Source/Reflection/Private/Importers/Types/Tables/StringTableImporter.cpp
+++ b/Source/Reflection/Private/Importers/Types/Tables/StringTableImporter.cpp
@@ -23,11 +23,16 @@ bool IStringTableImporter::Import() {
 		/* Set "SourceStrings" from KeysToEntries */
 		const TSharedPtr<FJsonObject> KeysToEntries = StringTableData->GetObjectField(TEXT("KeysToEntries"));
 	
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : KeysToEntries->Values) {
-			FString Key = Pair.Key;
+		for (const auto& Pair : KeysToEntries->Values) {
+			FString Key = JsonKeyToString(Pair.Key);
 			FString SourceString = Pair.Value->AsString();
 
+	#if UE5_8_BEYOND
+			/* 5.8 added a DevNotes parameter to the editor build's SetSourceString */
+			MutableStringTable->SetSourceString(Key, SourceString, TEXT(""));
+	#else
 			MutableStringTable->SetSourceString(Key, SourceString);
+	#endif
 		}
 
 		/* Set Metadata from KeysToMetaData */

--- a/Source/Reflection/Private/Importers/Types/UserDefined/UserDefinedEnumImporter.cpp
+++ b/Source/Reflection/Private/Importers/Types/UserDefined/UserDefinedEnumImporter.cpp
@@ -47,9 +47,12 @@ bool IUserDefinedEnumImporter::Import() {
 
 		/* Update the enumeration with the enum names */
 		UserDefinedEnum->SetEnums(EnumNames, CppForm
-			#if ENGINE_UE5 || ((ENGINE_UE4 && ENGINE_MINOR_VERSION >= 26) && !(ENGINE_MINOR_VERSION == 26 && ENGINE_PATCH_VERSION == 0))
+	#if UE5_8_BEYOND
+			/* 5.8 added UEnum::EUnderlyingType and replaced the bool with UEnum::EAddMaxKeyIfMissing */
+			, UEnum::EUnderlyingType::int32, EEnumFlags::None, UEnum::EAddMaxKeyIfMissing::Yes
+	#elif ENGINE_UE5 || ((ENGINE_UE4 && ENGINE_MINOR_VERSION >= 26) && !(ENGINE_MINOR_VERSION == 26 && ENGINE_PATCH_VERSION == 0))
 			, EEnumFlags::None, true
-			#endif
+	#endif
 		);
 	}
 	
@@ -78,7 +81,12 @@ bool IUserDefinedEnumImporter::Import() {
 			DisplayNames.Add(EnumKey, FText::FromString(*ValueObject->GetStringField(TEXT("CultureInvariantString"))));
 		} else {
 			/* TODO: Add LocalizedString */
+	#if UE5_8_BEYOND
+			/* ForUseOnlyByLocMacroAndGraphNodeTextLiterals_CreateText was removed in 5.8 */
+			DisplayNames.Add(EnumKey, FText::FromString(SourceString));
+	#else
 			DisplayNames.Add(EnumKey, FInternationalization::ForUseOnlyByLocMacroAndGraphNodeTextLiterals_CreateText(*SourceString, *TextNamespace, *UniqueKey));
+	#endif
 		}
 	}
 

--- a/Source/Reflection/Private/Importers/Types/UserDefined/UserDefinedStructImporter.cpp
+++ b/Source/Reflection/Private/Importers/Types/UserDefined/UserDefinedStructImporter.cpp
@@ -112,7 +112,7 @@ void IUserDefinedStructImporter::ImportPropertyIntoStruct(UUserDefinedStruct* Us
     FStructureEditorUtils::GetVarDesc(UserDefinedStruct).Add(Variable);
     FStructureEditorUtils::OnStructureChanged(UserDefinedStruct, FStructureEditorUtils::EStructureEditorChangeInfo::AddedVariable);
 
-    const TSharedPtr<FJsonValue>& PropertyJsonValue = DefaultProperties->Values.FindChecked(Name);
+    const TSharedPtr<FJsonValue>& PropertyJsonValue = DefaultProperties->Values.FindChecked(StringToJsonKey(Name));
 
     FProperty* Property = FindFProperty<FProperty>(UserDefinedStruct, *Name);
 

--- a/Source/Reflection/Private/Modules/Toolbar/Tools/ClearImportData.cpp
+++ b/Source/Reflection/Private/Modules/Toolbar/Tools/ClearImportData.cpp
@@ -44,7 +44,12 @@ void TToolClearImportData::Execute() {
 		}
 
 		if (const UStaticMesh* StaticMesh = Cast<UStaticMesh>(Asset)) {
+	#if UE4_27_AND_UE5
+			/* Direct member access was deprecated in 5.7; the accessor arrived in 4.27 */
+			StaticMesh->GetAssetImportData()->SourceData.SourceFiles.Empty();
+	#else
 			StaticMesh->AssetImportData->SourceData.SourceFiles.Empty();
+	#endif
 		}
 
 		if (const UTexture* Texture = Cast<UTexture>(Asset)) {

--- a/Source/Reflection/Private/Modules/Versioning.cpp
+++ b/Source/Reflection/Private/Modules/Versioning.cpp
@@ -66,7 +66,7 @@ void FReflectionVersioning::Update() {
 			return;
 		}
 		
-		Reset(ConvertVersionStringToInt(FRMetadata::Version), ConvertVersionStringToInt(JsonObject->GetStringField("name")), JsonObject->GetStringField(TEXT("html_url")), JsonObject->GetStringField(TEXT("name")), FRMetadata::Version);
+		Reset(ConvertVersionStringToInt(FRMetadata::Version), ConvertVersionStringToInt(JsonObject->GetStringField(TEXT("name"))), JsonObject->GetStringField(TEXT("html_url")), JsonObject->GetStringField(TEXT("name")), FRMetadata::Version);
 
 		static bool IsNotificationShown = false;
 

--- a/Source/Reflection/Private/Serializers/ObjectSerializer.cpp
+++ b/Source/Reflection/Private/Serializers/ObjectSerializer.cpp
@@ -320,18 +320,18 @@ void UObjectSerializer::DeserializeObjectProperties(const TSharedPtr<FJsonObject
 #if ENGINE_UE5
 		/* ExponentialHeightFog: Migration to new API */
 		if (Object->IsA<UExponentialHeightFogComponent>()) {
-			if (Property->NamePrivate == "FogInscatteringLuminance" && !Properties->Values.Contains("FogInscatteringLuminance")) {
+			if (Property->NamePrivate == "FogInscatteringLuminance" && !Properties->HasField(TEXT("FogInscatteringLuminance"))) {
 				PropertyName = "FogInscatteringColor";
 			}
 
-			if (Property->NamePrivate == "DirectionalInscatteringLuminance" && !Properties->Values.Contains("DirectionalInscatteringLuminance")) {
+			if (Property->NamePrivate == "DirectionalInscatteringLuminance" && !Properties->HasField(TEXT("DirectionalInscatteringLuminance"))) {
 				PropertyName = "DirectionalInscatteringColor";
 			}
 		}
 #endif
-		
+
 		if (Properties->HasField(PropertyName) && !HasHandledProperty && PropertyName != "LODParentPrimitive" && PropertyName != "bIsCookedForEditor") {
-			const TSharedPtr<FJsonValue>& ValueObject = Properties->Values.FindChecked(PropertyName);
+			const TSharedPtr<FJsonValue>& ValueObject = Properties->Values.FindChecked(StringToJsonKey(PropertyName));
 
 			if (Property->ArrayDim == 1 || ValueObject->Type == EJson::Array) {
 				PropertySerializer->DeserializePropertyValue(Property, ValueObject.ToSharedRef(), PropertyValue, Object);

--- a/Source/Reflection/Private/Serializers/PropertySerializer.cpp
+++ b/Source/Reflection/Private/Serializers/PropertySerializer.cpp
@@ -93,7 +93,7 @@ void UPropertySerializer::DeserializePropertyValue(FProperty* Property, const TS
 		FScriptSetHelper SetHelper(SetProperty, OutValue);
 		const TArray<TSharedPtr<FJsonValue>>& SetArray = NewJsonValue->AsArray();
 		SetHelper.EmptyElements();
-		uint8* TempElementStorage = static_cast<uint8*>(FMemory::Malloc(ElementProperty->ElementSize));
+		uint8* TempElementStorage = static_cast<uint8*>(FMemory::Malloc(GetElementSize(ElementProperty)));
 		ElementProperty->InitializeValue(TempElementStorage);
 
 		for (int32 i = 0; i < SetArray.Num(); i++) {
@@ -583,7 +583,12 @@ void UPropertySerializer::DeserializePropertyValue(FProperty* Property, const TS
 			if (Object->HasField(TEXT("CultureInvariantString"))) {
 				TextProperty->SetPropertyValue(OutValue, FText::FromString(*Object->GetStringField(TEXT("CultureInvariantString"))));
 			} else {
+	#if UE5_8_BEYOND
+				/* ForUseOnlyByLocMacroAndGraphNodeTextLiterals_CreateText was removed in 5.8 */
+				TextProperty->SetPropertyValue(OutValue, FText::FromString(SourceString));
+	#else
 				TextProperty->SetPropertyValue(OutValue, FInternationalization::ForUseOnlyByLocMacroAndGraphNodeTextLiterals_CreateText(*SourceString, *TextNamespace, *UniqueKey));
+	#endif
 			}
 		}
 	}

--- a/Source/Reflection/Private/Serializers/SerializerContainer.cpp
+++ b/Source/Reflection/Private/Serializers/SerializerContainer.cpp
@@ -17,7 +17,7 @@ void USerializerContainer::Initialize(FUObjectExport* Export, FUObjectExportCont
 
 	/* Move asset properties defined outside "Properties" and move it inside */
 	for (const auto& Pair : AssetExport->JsonObject->Values) {
-		const FString& PropertyName = Pair.Key;
+		const FString PropertyName = JsonKeyToString(Pair.Key);
     
 		if (!PropertyName.Equals(TEXT("Type")) &&
 			!PropertyName.Equals(TEXT("Name")) &&

--- a/Source/Reflection/Private/Serializers/Structs/FallbackStructSerializer.cpp
+++ b/Source/Reflection/Private/Serializers/Structs/FallbackStructSerializer.cpp
@@ -74,7 +74,7 @@ void FFallbackStructSerializer::Deserialize(UScriptStruct* Struct, void* StructV
 			const bool bHasHandledProperty = PassthroughPropertyHandler(Property, PropertyName, PropertyValue, JsonValue, PropertySerializer);
 
 			if (!bHasHandledProperty && JsonValue->HasField(ValueName)) {
-				const TSharedPtr<FJsonValue> ValueObject = JsonValue->Values.FindChecked(ValueName);
+				const TSharedPtr<FJsonValue> ValueObject = JsonValue->Values.FindChecked(StringToJsonKey(ValueName));
 
 				if (Property->ArrayDim == 1 || ValueObject->Type == EJson::Array) {
 					PropertySerializer->DeserializePropertyValue(Property, ValueObject.ToSharedRef(), PropertyValue, OptionalOuter);

--- a/Source/Reflection/Public/Containers/Export.h
+++ b/Source/Reflection/Public/Containers/Export.h
@@ -201,7 +201,12 @@ struct REFLECTION_API FUObjectExport : FUObjectJsonValueExport {
 		}
 
 		if (bRemoveLast && Result.Num() > 0) {
+	#if UE5_6_BEYOND
+			/* Pop's bool parameter became EAllowShrinking in 5.4, and the bool overload was removed in 5.8 */
+			Result.Pop(EAllowShrinking::No);
+	#else
 			Result.Pop(false);
+	#endif
 		}
 
 		return Result;

--- a/Source/Reflection/Public/Containers/JsonValueExport.h
+++ b/Source/Reflection/Public/Containers/JsonValueExport.h
@@ -89,7 +89,7 @@ struct REFLECTION_API FUObjectJsonValueExport {
 #if UE4_24_BELOW
 		const TSharedPtr<FJsonValue>* Field = JsonObject->Values.Find(FieldName);
 #else
-		const TSharedPtr<FJsonValue>* Field = JsonObject->Values.FindByHash(GetTypeHash(FieldName), FieldName);
+		const TSharedPtr<FJsonValue>* Field = JsonObject->Values.FindByHash(GetTypeHash(StringToJsonKey(FieldName)), StringToJsonKey(FieldName));
 #endif
 		if (Field == nullptr || !Field->IsValid()) {
 			static const TSharedPtr<FJsonObject> EmptyObject = MakeShared<FJsonObject>();

--- a/Source/Reflection/Public/Engine/Compatibility.h
+++ b/Source/Reflection/Public/Engine/Compatibility.h
@@ -28,6 +28,12 @@
 	#define ENGINE_UE5 0
 #endif
 
+#if ENGINE_UE5 && ENGINE_MINOR_VERSION >= 8
+	#define UE5_8_BEYOND 1
+#else
+	#define UE5_8_BEYOND 0
+#endif
+
 #if ENGINE_UE5 && ENGINE_MINOR_VERSION >= 6
 	#define UE5_6_BEYOND 1
 #else
@@ -297,6 +303,36 @@ inline FGuid StringToGuid(const FString& GuidString) {
 	return FGuid(GuidString);
 #endif
 }
+
+/* 5.8 moved FJsonObject's Values map onto UE::FSharedString keys, which convert to FString only explicitly */
+#if UE5_8_BEYOND
+#include "Containers/SharedString.h"
+#endif
+
+#if UE5_8_BEYOND
+inline FString JsonKeyToString(const FString& Key) {
+	return Key;
+}
+
+inline FString JsonKeyToString(const UE::FSharedString& Key) {
+	return FString(*Key);
+}
+#else
+/* Before 5.8 the key already is an FString, so hand the reference through untouched */
+inline const FString& JsonKeyToString(const FString& Key) {
+	return Key;
+}
+#endif
+
+#if UE5_8_BEYOND
+inline UE::FSharedString StringToJsonKey(const FString& Key) {
+	return UE::FSharedString(*Key);
+}
+#else
+inline const FString& StringToJsonKey(const FString& Key) {
+	return Key;
+}
+#endif
 
 #if UE4_26_0
 #include "AssetRegistry/Public/AssetRegistryModule.h"

--- a/Source/Reflection/Public/Engine/Notifications.h
+++ b/Source/Reflection/Public/Engine/Notifications.h
@@ -111,7 +111,7 @@ inline void RemoveNotification(TWeakPtr<SNotificationItem>& Notification) {
 	const TSharedPtr<SNotificationItem> Item = Notification.Pin();
 
 	if (Item.IsValid()) {
-		Item->SetFadeOutDuration(0.001);
+		Item->SetFadeOutDuration(0.001f);
 		Item->Fadeout();
 	}
 

--- a/Source/Reflection/Public/Engine/Properties.h
+++ b/Source/Reflection/Public/Engine/Properties.h
@@ -72,7 +72,10 @@ inline EObjectFlags ParseObjectFlags(const FString& FlagsString) {
 
 		{ TEXT("RF_NeedInitialization"), RF_NeedInitialization },
 		{ TEXT("RF_NeedLoad"), RF_NeedLoad },
+	/* RF_KeepForCooker was deprecated in 5.6 */
+#if !UE5_6_BEYOND
 		{ TEXT("RF_KeepForCooker"), RF_KeepForCooker },
+#endif
 		{ TEXT("RF_NeedPostLoad"), RF_NeedPostLoad },
 		{ TEXT("RF_NeedPostLoadSubobjects"), RF_NeedPostLoadSubobjects },
 		{ TEXT("RF_NewerVersionExists"), RF_NewerVersionExists },
@@ -92,11 +95,17 @@ inline EObjectFlags ParseObjectFlags(const FString& FlagsString) {
 		{ TEXT("RF_HasExternalPackage"), RF_HasExternalPackage },
 #endif
 #if ENGINE_UE5
-#if ENGINE_MINOR_VERSION > 3
+	/* RF_HasPlaceholderType arrived in 5.4 and was removed in 5.8; RF_MirroredGarbage is 5.4+ */
+#if ENGINE_MINOR_VERSION > 3 && ENGINE_MINOR_VERSION < 8
 		{ TEXT("RF_HasPlaceholderType"), RF_HasPlaceholderType },
+#endif
+#if ENGINE_MINOR_VERSION > 3
 		{ TEXT("RF_MirroredGarbage"), RF_MirroredGarbage },
 #endif
+	/* RF_AllocatedInSharedPage was deprecated in 5.8; its bit was reassigned to RF_HasDynamicImports */
+#if !UE5_8_BEYOND
 		{ TEXT("RF_AllocatedInSharedPage"), RF_AllocatedInSharedPage }
+#endif
 #endif
 	};
 

--- a/Source/Reflection/Public/Serializers/PropertySerializer.h
+++ b/Source/Reflection/Public/Serializers/PropertySerializer.h
@@ -58,7 +58,7 @@ inline bool PassthroughPropertyHandler(FProperty* Property, const FString& Prope
 
 		/* Finds array elements with the format: PropertyName[Index] and sets them properly into an array */
 		for (const auto& Pair : Properties->Values) {
-			const FString& Key = Pair.Key;
+			const FString Key = JsonKeyToString(Pair.Key);
 			const TSharedPtr<FJsonValue> Value = Pair.Value;
 
 			/* If it doesn't start with the same property name */

--- a/Source/Reflection/Public/Utilities/JsonHelpers.h
+++ b/Source/Reflection/Public/Utilities/JsonHelpers.h
@@ -74,7 +74,7 @@ inline void ProcessObjects(const TSharedPtr<FJsonObject>& Parent, const TFunctio
 
 		if (Pair.Value->Type == EJson::Object) {
 			if (const TSharedPtr<FJsonObject> ChildObject = Pair.Value->AsObject()) {
-				ProcessObjectFunction(Pair.Key, ChildObject);
+				ProcessObjectFunction(JsonKeyToString(Pair.Key), ChildObject);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes compilation on Unreal Engine 5.8 while keeping 4.22–5.7 support intact.

The plugin failed to build on 5.8 with 40 errors. Root causes and fixes:

## 5.8 API changes

- **`FJsonObject` shared-string keys** (30 errors): 5.8 moved `FJsonObject::Values` to
  `UE::FSharedString` keys and switched all accessors to `FStringView`. New `UE5_8_BEYOND`
  macro and two shims in `Compatibility.h` (`JsonKeyToString` / `StringToJsonKey`) convert
  between key types; call sites stay version-agnostic. `HarvestAndTagConnectedStateMachineNodes`
  is now templated on the key type; `Values.Find/GetKeys` calls were replaced with
  shim-based equivalents.
- **`TArray::Pop(bool)` → `Pop(EAllowShrinking)`** (deprecated 5.4, removed 5.8): version-gated.
- **`RF_HasPlaceholderType` removed** (added 5.4, removed 5.8): flag-map entry gated to 5.4–5.7;
  deprecated `RF_KeepForCooker` (5.6) and `RF_AllocatedInSharedPage` (5.8) entries dropped on
  the versions that deprecated them.
- **`FStringTable::SetSourceString`** gained a DevNotes parameter in editor builds: 5.8 branch
  passes `TEXT("")`.
- **`UUserDefinedEnum::SetEnums`** gained `UEnum::EUnderlyingType` + `EAddMaxKeyIfMissing`:
  5.8 branch passes `int32` / `Yes` (matches the old `true`).
- **`FInternationalization::ForUseOnlyByLocMacroAndGraphNodeTextLiterals_CreateText` removed**:
  replaced with `FText::FromString` (same culture-invariant behaviour) on 5.8.
- **`FJsonObject` accessors take `FStringView`**: bare ANSI literals no longer convert, wrapped
  in `TEXT()`.

## 5.5 / 5.7 deprecations (warn now, break next release — cleaned up too)

- `FProperty::ElementSize` → `GetElementSize` (deprecated 5.5)
- Non-const `UMovieScene::GetBindings` → const overload (deprecated 5.7)
- `TSoftObjectPtr` assignment from a `const` pointer → drop the `const` (deprecated 5.5)
- `UStaticMesh::AssetImportData` direct access → `GetAssetImportData()` (deprecated 5.7)

## Verification

- Built with UE 5.8.1: 0 errors, 0 plugin warnings.
- Older engines keep the original code path: every version-gated branch falls back to the
  pre-existing code below the threshold version, and the shims resolve to identity conversions
  on 4.22–5.7.