### PR TITLE
Fix editor shutdown crash (UE 5.8)

### DIFF
--- a/Source/Reflection/Private/Reflection.cpp
+++ b/Source/Reflection/Private/Reflection.cpp
@@ -98,7 +98,11 @@ void FReflectionModule::ShutdownModule() {
 	FReflectionStyle::Shutdown();
 
 	if (Toolbar) {
+#if UE4_23_BELOW
+		if (!GIsRequestingExit) {
+#else
 		if (!IsEngineExitRequested()) {
+#endif
 			Toolbar->RemoveFromRoot();
 		}
 		Toolbar = nullptr;

--- a/Source/Reflection/Private/Reflection.cpp
+++ b/Source/Reflection/Private/Reflection.cpp
@@ -98,7 +98,9 @@ void FReflectionModule::ShutdownModule() {
 	FReflectionStyle::Shutdown();
 
 	if (Toolbar) {
-		Toolbar->RemoveFromRoot();
+		if (!IsEngineExitRequested()) {
+			Toolbar->RemoveFromRoot();
+		}
 		Toolbar = nullptr;
 	}
 }


### PR DESCRIPTION
## Problem

Closing the editor with UE 5.8 crashes with:

Assertion failed: Index >= 0 [File:...\CoreUObject\Public\UObject\UObjectArray.h] [Line: 1083]

Callstack:

FDebug::CheckVerifyFailedImpl2()
FUObjectArray::IndexToObject() [UObjectArray.h:1083]
FReflectionModule::ShutdownModule() [Reflection.cpp:101]
FModuleManager::UnloadModulesAtShutdown() [ModuleManager.cpp:1493]
FEngineLoop::Exit() [LaunchEngineLoop.cpp:5182]

## Root cause

UE 5.8 shutdown order: `FEngineLoop::Exit()` first calls `AppPreExit()` (LaunchEngineLoop.cpp:5123), which broadcasts `FCoreDelegates::OnExit` → `StaticExit()` → `PurgeAllUObjectsOnExit()`. This destroys **all** UObjects — including root-set ones — before any module is unloaded (log shows `Object subsystem successfully closed.` before `ShutdownModule()` runs).

`ShutdownModule()` then calls `Toolbar->RemoveFromRoot()` on an already-destroyed UObject. In UE 5.8 `RemoveFromRoot()` resolves the object via `GUObjectArray.IndexToObject(InternalIndex)`, and destroyed objects now hold `InternalIndex == INDEX_NONE`; the new `check(Index >= 0)` turns this pre-existing dangling access into a deterministic crash (older engines hit undefined behavior silently).

## Fix

Skip `RemoveFromRoot()` while the engine is exiting — the object system is destroyed anyway. Normal module unloads (hot reload, plugin disable) still unroot as before.

## Verification

- UE 5.8.1, Windows, Development Editor: editor exits cleanly — log reaches `LogExit: Exiting.` with no assertion (previously crashed right after `LogExit: Object subsystem successfully closed.`).
- Mid-session module unload (hot reload) behavior unchanged, as `IsEngineExitRequested()` is false there.