### PR TITLE
Physics asset importing (unattended runs)

### DIFF
--- a/Source/Reflection/Private/Importers/Types/Physics/PhysicsAssetImporter.cpp
+++ b/Source/Reflection/Private/Importers/Types/Physics/PhysicsAssetImporter.cpp
@@ -97,12 +97,6 @@ bool IPhysicsAssetImporter::Import() {
 		AssetRegistryModule.Get().GetAssetsByPath(FName(*SearchPath), AssetDataList, false);
 
 		for (const FAssetData& AssetData : AssetDataList) {
-			const UClass* AssetClass = AssetData.GetClass();
-
-			if (!AssetClass || !AssetClass->IsChildOf(USkeletalMesh::StaticClass())) {
-				continue;
-			}
-
 			SkeletalMesh = Cast<USkeletalMesh>(AssetData.GetAsset());
 
 			if (SkeletalMesh) {
@@ -110,7 +104,7 @@ bool IPhysicsAssetImporter::Import() {
 			}
 		}
 	}
-	
+
 	if (SkeletalMesh) {
 		PhysicsAsset->PreviewSkeletalMesh = SkeletalMesh;
 		PhysicsAsset->PostEditChange();


### PR DESCRIPTION
Fix skeletal mesh lookup in unattended imports.

`FAssetData::GetClass()` only returns classes that are already loaded,
so in a headless import every candidate was skipped and the
PhysicsAsset ended up without a preview mesh. Load the asset with
`GetAsset()` and let the cast decide instead — a version-neutral call
that also loads the mesh.
