### PR TITLE
Fix rig/DNA importer compilation (UE 5.8)

### DIFF
--- a/Source/Reflection/Private/Commandlets/RigImportCommandlet.cpp
+++ b/Source/Reflection/Private/Commandlets/RigImportCommandlet.cpp
@@ -1,6 +1,7 @@
 /* Copyright Reflection Contributors 2024-2026 */
 
 #include "RigImportCommandlet.h"
+#include "Engine/Compatibility.h"
 
 #if REFLECTION_CONTROL_RIG
 
@@ -10,7 +11,11 @@
 #include "Modules/Cloud/Cloud.h"
 #include "Settings/SettingsAccess.h"
 
+#if UE5_7_BEYOND
+#include "ControlRigBlueprintLegacy.h"
+#else
 #include "ControlRigBlueprint.h"
+#endif
 #include "Engine/SkeletalMesh.h"
 #include "Rendering/SkeletalMeshModel.h"
 #include "Rendering/SkeletalMeshLODModel.h"
@@ -90,16 +95,22 @@ static void ReportDna(USkeletalMesh* Mesh, const TCHAR* Prefix) {
 		UDNAAsset* DNAAsset = Cast<UDNAAsset>(Entry);
 		if (DNAAsset == nullptr) continue;
 
+#if UE5_8_BEYOND
+		const FString& DnaFileName = DNAAsset->DnaFileName_DEPRECATED;
+#else
+		const FString& DnaFileName = DNAAsset->DnaFileName;
+#endif
+
 		const TSharedPtr<IDNAReader> Behavior = DNAAsset->GetBehaviorReader();
 
 		if (!Behavior.IsValid()) {
-			UE_LOG(LogRigImportTest, Display, TEXT("%s dna '%s': no behavior"), Prefix, *DNAAsset->DnaFileName);
+			UE_LOG(LogRigImportTest, Display, TEXT("%s dna '%s': no behavior"), Prefix, *DnaFileName);
 
 			continue;
 		}
 
 		UE_LOG(LogRigImportTest, Display, TEXT("%s dna '%s': name %s, db %s, %d lods, %d joints, %d blend shapes, %d raw controls, %d meshes"),
-			Prefix, *DNAAsset->DnaFileName, *Behavior->GetName(), *Behavior->GetDBName(),
+			Prefix, *DnaFileName, *Behavior->GetName(), *Behavior->GetDBName(),
 			Behavior->GetLODCount(), Behavior->GetJointCount(), Behavior->GetBlendShapeChannelCount(),
 			Behavior->GetRawControlCount(), Behavior->GetMeshCount());
 
@@ -174,7 +185,11 @@ static void ReportDnaNeutral(USkeletalMesh* Mesh) {
 
 	FRigLogic RigLogic(Behavior.Get());
 
+#if UE5_5_BEYOND
+	const TArrayView<const float> Neutral = RigLogic.GetNeutralJointValues();
+#else
 	const TArrayView<const float> Neutral = RigLogic.GetRawNeutralJointValues();
+#endif
 	const FReferenceSkeleton& RefSkeleton = Mesh->GetRefSkeleton();
 
 	int32 Compared = 0;
@@ -1486,8 +1501,14 @@ int32 URigImportCommandlet::Main(const FString& Params) {
 				const FRigVMExecuteOp& Op = Code.GetOpAt<FRigVMExecuteOp>(Instruction);
 				const TArray<const FRigVMFunction*>& Functions = VM->GetFunctions();
 
-				if (Functions.IsValidIndex(Op.FunctionIndex) && Functions[Op.FunctionIndex] != nullptr) {
-					Calls.FindOrAdd(Functions[Op.FunctionIndex]->Name)++;
+#if UE5_8_BEYOND
+				const int32 FunctionIndex = Op.CallableIndex;
+#else
+				const int32 FunctionIndex = Op.FunctionIndex;
+#endif
+
+				if (Functions.IsValidIndex(FunctionIndex) && Functions[FunctionIndex] != nullptr) {
+					Calls.FindOrAdd(Functions[FunctionIndex]->Name)++;
 				}
 			}
 

--- a/Source/Reflection/Private/Importers/Types/Mesh/SkeletalMeshImporter.cpp
+++ b/Source/Reflection/Private/Importers/Types/Mesh/SkeletalMeshImporter.cpp
@@ -417,7 +417,11 @@ bool ISkeletalMeshImporter::ApplyDna(USkeletalMesh* SkeletalMesh, const FString&
 		SkeletalMesh->AddAssetUserData(DNAAsset);
 	}
 
+#if UE5_8_BEYOND
+	DNAAsset->DnaFileName_DEPRECATED = SkeletalMesh->GetName() + TEXT(".dna");
+#else
 	DNAAsset->DnaFileName = SkeletalMesh->GetName() + TEXT(".dna");
+#endif
 	DNAAsset->SetBehaviorReader(Behavior);
 
 	/* Some heads keep the DNA in a package of its own and only the definition with it: the names,
@@ -569,7 +573,11 @@ bool ISkeletalMeshImporter::AlignBindPoseToDna(USkeletalMesh* SkeletalMesh) {
 	 * two do not report a rotation the same way round, and this is the pair that has to agree. */
 	FRigLogic RigLogic(Behavior.Get());
 
+#if UE5_5_BEYOND
+	const TArrayView<const float> Neutral = RigLogic.GetNeutralJointValues();
+#else
 	const TArrayView<const float> Neutral = RigLogic.GetRawNeutralJointValues();
+#endif
 
 	int32 Aligned = 0;
 
@@ -626,7 +634,11 @@ UPoseAsset* ISkeletalMeshImporter::BakeDnaPoseAsset(USkeletalMesh* SkeletalMesh)
 	FRigLogic RigLogic(Behavior.Get());
 	FRigInstance Instance(&RigLogic);
 
+#if UE5_5_BEYOND
+	const TArrayView<const float> Neutral = RigLogic.GetNeutralJointValues();
+#else
 	const TArrayView<const float> Neutral = RigLogic.GetRawNeutralJointValues();
+#endif
 
 	/* A DNA names the joints it drives, and the mesh knows them as bones. Only those get a track:
 	 * everything else stays wherever the pose it is played over left it. */
@@ -698,7 +710,11 @@ UPoseAsset* ISkeletalMeshImporter::BakeDnaPoseAsset(USkeletalMesh* SkeletalMesh)
 
 		RigLogic.Calculate(&Instance);
 
+#if UE5_5_BEYOND
+		WriteFrame(Instance.GetJointOutputs());
+#else
 		WriteFrame(Instance.GetRawJointOutputs());
+#endif
 
 		/* A control is named with a dot between its group and itself, which reads as a path
 		 * everywhere a curve name is typed */

--- a/Source/Reflection/Private/Importers/Types/Rig/ControlRigImporter.cpp
+++ b/Source/Reflection/Private/Importers/Types/Rig/ControlRigImporter.cpp
@@ -5,7 +5,13 @@
 #if REFLECTION_CONTROL_RIG
 
 #include "ControlRig.h"
+
+#if UE5_7_BEYOND
+#include "ControlRigBlueprintLegacy.h"
+#else
 #include "ControlRigBlueprint.h"
+#endif
+
 #include "ControlRigBlueprintFactory.h"
 #include "Rigs/RigHierarchyController.h"
 

--- a/Source/Reflection/Private/Importers/Types/Rig/RigVMGraph.cpp
+++ b/Source/Reflection/Private/Importers/Types/Rig/RigVMGraph.cpp
@@ -4,7 +4,11 @@
 
 #if REFLECTION_CONTROL_RIG
 
+#if UE5_7_BEYOND
+#include "ControlRigBlueprintLegacy.h"
+#else
 #include "ControlRigBlueprint.h"
+#endif
 
 #include "RigVMCore/RigVMDispatchFactory.h"
 #include "RigVMCore/RigVMRegistry.h"
@@ -17,9 +21,12 @@
 #include "Serializers/PropertySerializer.h"
 
 namespace {
-	/* The registry grew a read and a write half in 5.5, and every use here only reads */
+	/* The registry grew a read and a write half in 5.5, and every use here only reads.
+	 * 5.8 dropped the read-only entry point and folded the registry back into the RW lock. */
 	FORCEINLINE decltype(auto) GetRigVMRegistry() {
-#if UE5_5_BEYOND
+#if UE5_8_BEYOND
+		return FRigVMRegistry::Get();
+#elif UE5_5_BEYOND
 		return FRigVMRegistry::GetForRead();
 #else
 		return FRigVMRegistry::Get();
@@ -466,7 +473,11 @@ void FRigVMGraphReconstruction::CollectNodes(const TArray<FUObjectJsonValueExpor
 			}
 
 			if (Function->Factory != nullptr) {
+#if UE5_7_BEYOND
+				for (const FRigVMTemplateArgumentInfo& Info : Function->Factory->GetArgumentInfos(FRigVMRegistry::Get().GetHandle_NoLock())) {
+#else
 				for (const FRigVMTemplateArgumentInfo& Info : Function->Factory->GetArgumentInfos()) {
+#endif
 					if (Info.Name.ToString() == ArgumentName) {
 						return Info.Direction == ERigVMPinDirection::Output || Info.Direction == ERigVMPinDirection::IO;
 					}
@@ -512,7 +523,12 @@ void FRigVMGraphReconstruction::CollectNodes(const TArray<FUObjectJsonValueExpor
 				Node.ArgumentIsOutput.Add(true);
 			} else {
 				for (int32 OperandIndex = 0; OperandIndex < OperandCount; ++OperandIndex) {
+				/* 5.7 gave the name lookup a registry handle to read through */
+#if UE5_7_BEYOND
+					const FString ArgumentName = Function->GetArgumentNameForOperandIndex(OperandIndex, OperandCount, FRigVMRegistry::Get().GetHandle_NoLock()).ToString();
+#else
 					const FString ArgumentName = Function->GetArgumentNameForOperandIndex(OperandIndex, OperandCount).ToString();
+#endif
 
 					Node.Arguments.Add(ArgumentName);
 					Node.ArgumentIsOutput.Add(IsOutputArgument(ArgumentName));

--- a/Source/Reflection/Private/Modules/Cloud/Tools/SkeletalMeshData.cpp
+++ b/Source/Reflection/Private/Modules/Cloud/Tools/SkeletalMeshData.cpp
@@ -11,7 +11,11 @@
 
 /* Profiles are two halves: the entries on the mesh, the weights on the imported model */
 #if UE4_27_AND_UE5
+#if UE5_8_BEYOND
+#include "Rendering/SkinWeightProfile.h"
+#else
 #include "Animation/SkinWeightProfile.h"
+#endif
 #include "GPUSkinPublicDefs.h"
 #include "Modules/Cloud/Cloud.h"
 #include "Rendering/SkeletalMeshModel.h"

--- a/Source/Reflection/Public/Engine/Compatibility.h
+++ b/Source/Reflection/Public/Engine/Compatibility.h
@@ -46,6 +46,12 @@
 	#define UE5_8_BEYOND 0
 #endif
 
+#if ENGINE_UE5 && ENGINE_MINOR_VERSION >= 7
+	#define UE5_7_BEYOND 1
+#else
+	#define UE5_7_BEYOND 0
+#endif
+
 #if ENGINE_UE5 && ENGINE_MINOR_VERSION >= 6
 	#define UE5_6_BEYOND 1
 #else


### PR DESCRIPTION
## Problem

The Control Rig and DNA (RigLogic) importers fail to compile on UE 5.8
(C1083 / C2039 / C2660): the APIs they were written against were renamed,
moved, or removed by 5.8.

## Changes

- **`ControlRigBlueprint.h` → `ControlRigBlueprintLegacy.h`** (5.7): includes gated on the new
  `UE5_7_BEYOND` macro in `Compatibility.h`.
- **RigVM registry** (5.8): `GetForRead()` deleted → reads go through `FRigVMRegistry::Get()`;
  `GetType` stays on the wrapper (`_NoLock` spellings are protected now).
- **`FRigVMExecuteOp::FunctionIndex` → `CallableIndex`** (5.8): the index moved to the
  `FRigVMInvokeCallableOp` base.
- **`GetArgumentInfos` / `GetArgumentNameForOperandIndex`** (5.7): gained a `FRigVMRegistryHandle&`
  parameter; calls pass `FRigVMRegistry::Get().GetHandle_NoLock()`.
- **`UDNAAsset::DnaFileName` → `DnaFileName_DEPRECATED`** (5.8).
- **`Animation/SkinWeightProfile.h` → `Rendering/SkinWeightProfile.h`** (5.8).
- **5.5 renames**: `GetRawNeutralJointValues` → `GetNeutralJointValues`,
  `GetRawJointOutputs` → `GetJointOutputs`.

## Verification

- Built with UE 5.8: 0 errors. Remaining warnings are C4996 deprecations from pre-existing code,
  not introduced here.
- Older engines keep the original code path below each threshold version.